### PR TITLE
Change title to "Data Carpentry @ UW-Madison

### DIFF
--- a/_includes/workshop_ad.html
+++ b/_includes/workshop_ad.html
@@ -5,7 +5,7 @@
   <div class="row">
 
     <div class="col-md-10 col-md-offset-1">
-      <h2>A Data Carpentry Workshop</h2>
+      <h2>Data Carpentry @ UW&ndash;Madison</h2>
 
       <h2>{{page.venue}}</h2>
       <div class="row">


### PR DESCRIPTION
Change title on main page to be like the page for the SWC workshop. That is, change it from "A Data Carpentry Workshop" to "Data Carpentry @ UW-Madison".